### PR TITLE
Specify ISO-8859-1 to avoid build errors

### DIFF
--- a/fdahpStudyDesigner-master/fdahpStudyDesigner/pom.xml
+++ b/fdahpStudyDesigner-master/fdahpStudyDesigner/pom.xml
@@ -9,6 +9,7 @@
 	<description>Studies Gateway Web Application</description>
 	<url>http://maven.apache.org</url>
 	<properties>
+		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
 		<app.dir.name>fdahpStudyDesigner</app.dir.name>
 		<org.springframework.version>3.2.8.RELEASE</org.springframework.version>
 		<spring.security.version>3.2.3.RELEASE</spring.security.version>


### PR DESCRIPTION
Added a line in pom.xml to set file encoding to ISO-8859-1 to avoid build errors on machines that default to UTF-8.