### PR TITLE
Updates per platform modules updates

### DIFF
--- a/mobileAppStudy-ResponseServer/src/org/labkey/mobileappstudy/MobileAppStudyController.java
+++ b/mobileAppStudy-ResponseServer/src/org/labkey/mobileappstudy/MobileAppStudyController.java
@@ -360,7 +360,7 @@ public class MobileAppStudyController extends SpringActionController
                 return;
             }
 
-            Set<String> listIds = DataRegionSelection.getSelected(getViewContext(), form.getKey(), true, false);
+            Set<String> listIds = DataRegionSelection.getSelected(getViewContext(), form.getKey(), false);
             _ids = listIds.stream().map(Integer::valueOf).collect(Collectors.toSet());
 
             if (_ids.isEmpty())
@@ -527,7 +527,7 @@ public class MobileAppStudyController extends SpringActionController
 
         @NotNull
         @Override
-        public UserSchema getSchema()
+        public UserSchema createSchema()
         {
             return _userSchema;
         }


### PR DESCRIPTION
- this DataRegionSelection.getSelected method no longer takes two booleans, since the 'mergeSession' parameter was eliminated in the platform modules' Pull #406
- the override of getSchema should now be one of createSchema, per Issue #38951 in the platform modules repo commit SHA e21cb
- simply removing the true parameter is fine, since the method was modified to behave as such anyhow